### PR TITLE
Allow mutable installs for ui tests updates

### DIFF
--- a/ui-tests/.yarnrc.yml
+++ b/ui-tests/.yarnrc.yml
@@ -1,0 +1,1 @@
+enableImmutableInstalls: false


### PR DESCRIPTION
Snapshots update for #5 failed due to immutable installs restriction (
https://github.com/nebari-dev/jupyterlab-new-launcher/actions/runs/8970187175/job/24633152664). This restriction is lifted for UI tests via environment variable in workflows, but not for UI tests updates; this PR should lift it for snapshot updates too
