### PR TITLE
Allow users to configure section collapse status

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -28,7 +28,42 @@
     "starredSection": {
       "type": "boolean",
       "title": "Show starred section"
+    },
+    "collapsedSections": {
+      "title": "Collapsed sections",
+      "description": "Whether to start launcher with given section collapsed.",
+      "type": "object",
+      "default": {
+        "create-empty": "expanded",
+        "starred": "expanded",
+        "launch-notebook": "expanded",
+        "launch-console": "collapsed"
+      },
+      "properties": {
+        "create-empty": {
+          "title": "Create Empty",
+          "$ref": "#/$defs/collapseState"
+        },
+        "starred": {
+          "title": "Starred",
+          "$ref": "#/$defs/collapseState"
+        },
+        "launch-notebook": {
+          "title": "Launch Notebook",
+          "$ref": "#/$defs/collapseState"
+        },
+        "launch-console": {
+          "title": "Launch Console",
+          "$ref": "#/$defs/collapseState"
+        }
+      }
     }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "$defs": {
+    "collapseState": {
+      "type": "string",
+      "enum": ["collapsed", "expanded"]
+    }
+  }
 }

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -9,12 +9,17 @@ export function CollapsibleSection(
     className: string;
     icon: LabIcon;
     open: boolean;
+    onToggled?: (open: boolean) => void;
   }>
 ) {
   const [open, setOpen] = React.useState<boolean>(props.open);
 
-  const handleToggle = (event: { currentTarget: { open: boolean } }) =>
+  const handleToggle = (event: { currentTarget: { open: boolean } }) => {
     setOpen(event.currentTarget.open);
+    if (props.onToggled) {
+      props.onToggled(event.currentTarget.open);
+    }
+  };
 
   return (
     <details

--- a/src/launcher.tsx
+++ b/src/launcher.tsx
@@ -87,6 +87,9 @@ function LauncherBody(props: {
     item => item.starred
   );
 
+  const startCollapsed = props.settings.composite
+    .collapsedSections as ISettingsLayout['collapsedSections'];
+
   return (
     <div className="jp-LauncherBody">
       <div className="jp-NewLauncher-TopBar">
@@ -115,7 +118,7 @@ function LauncherBody(props: {
         className="jp-Launcher-openByType"
         title={trans.__('Create Empty')}
         icon={fileIcon}
-        open={true} // TODO: store this in layout/state higher up
+        open={startCollapsed['create-empty'] !== 'collapsed'}
       >
         {typeItems
           .filter(
@@ -132,7 +135,7 @@ function LauncherBody(props: {
           className="jp-Launcher-openByKernel"
           title={trans.__('Starred')}
           icon={starIcon}
-          open={true} // TODO: store this in layout/state higher up
+          open={startCollapsed['starred'] !== 'collapsed'}
         >
           {starred.length > 0 ? (
             <KernelTable
@@ -154,7 +157,7 @@ function LauncherBody(props: {
         className="jp-Launcher-openByKernel jp-Launcher-launchNotebook"
         title={trans.__('Launch Notebook')}
         icon={notebookIcon}
-        open={true} // TODO: store this in layout/state higher up
+        open={startCollapsed['launch-notebook'] !== 'collapsed'}
       >
         <KernelTable
           items={props.notebookItems}
@@ -170,7 +173,7 @@ function LauncherBody(props: {
         className="jp-Launcher-openByKernel jp-Launcher-launchConsole"
         title={trans.__('Launch Console')}
         icon={consoleIcon}
-        open={false}
+        open={startCollapsed['launch-console'] !== 'collapsed'}
       >
         <KernelTable
           items={props.consoleItems}

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface ISettingsLayout {
   hiddenColumns: Record<string, 'visible' | 'hidden'>;
   columnOrder: string[];
   starredSection: boolean;
+  collapsedSections: Record<string, 'collapsed' | 'expanded'>;
 }
 
 export interface IItem extends ILauncher.IItemOptions {


### PR DESCRIPTION
Resolves a set of TODO comments on making the initial collapse status user-configurable