### PR TITLE
Fix conda-store environment name regression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-new-launcher",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "description": "A redesigned JupyterLab launcher",
     "keywords": [
         "jupyter",

--- a/src/item.ts
+++ b/src/item.ts
@@ -57,13 +57,14 @@ export class Item implements IItem {
         this.label =
           (kernel['conda_language'] as string | undefined) ??
           groups.environment;
-        delete kernel['conda_env_name'];
+        const kernelCopy = { ...kernel };
+        delete kernelCopy['conda_env_name'];
         this.metadata = {
           ...this.metadata,
           kernel: {
             Namespace: groups.namespace,
             conda_env_name: groups.environment,
-            ...kernel
+            ...kernelCopy
           }
         };
       }


### PR DESCRIPTION
## Reference Issues or PRs

Follow-up to https://github.com/nebari-dev/jupyterlab-new-launcher/pull/43 which broke the extraction of environment from conda-store envs by overriding the original `kernel` object. Now the copy gets modified instead.

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [ ] Did you test the pull request locally?
- [ ] Did you add new tests?
