### PR TITLE
Fix sorting for last used column

### DIFF
--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -266,7 +266,7 @@ export function KernelTable(props: {
         if (!b.lastUsed) {
           return -1;
         }
-        return a.lastUsed > b.lastUsed ? 1 : -1;
+        return a.lastUsed > b.lastUsed ? -1 : 1;
       }
     },
     {


### PR DESCRIPTION
## Reference Issues or PRs

Fixes #49 - ensures that first click on the column sorts from most recent to not used at all:

![image](https://github.com/nebari-dev/jupyterlab-new-launcher/assets/5832902/194c2c2d-5063-4ab5-a1d9-40336e90d67c)

## What does this implement/fix?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?