### PR TITLE
Disable activity tracking on `DatabaseHandler` to allow idle server shutdown

### DIFF
--- a/jupyterlab_launchpad/handlers.py
+++ b/jupyterlab_launchpad/handlers.py
@@ -8,6 +8,7 @@ import tornado
 
 
 class DatabaseHandler(APIHandler):
+    _track_activity = False
 
     def initialize(self, name: str, settings_dir: str):
         self.path = Path(settings_dir) / "jupyterlab-launchpad" / f"{name}.json"

--- a/jupyterlab_launchpad/handlers.py
+++ b/jupyterlab_launchpad/handlers.py
@@ -8,6 +8,8 @@ import tornado
 
 
 class DatabaseHandler(APIHandler):
+    # Polling this handler every 10s resets jupyter_server's api_last_activity,
+    # preventing shutdown_no_activity_timeout from ever firing.
     _track_activity = False
 
     def initialize(self, name: str, settings_dir: str):


### PR DESCRIPTION
## Summary

`DatabaseHandler` extends `APIHandler`, which sets `_track_activity = True` by default. The launchpad extension polls two endpoints every 10 seconds:

- `GET /jupyterlab-launchpad/database/last-used`
- `GET /jupyterlab-launchpad/database/favorites`

Each response triggers `update_api_activity()` in `jupyter_server`, which resets the activity clock used by `ServerApp.shutdown_no_activity_timeout`. This prevents JupyterHub's idle culler from ever shutting down a singleuser server — the server appears perpetually "active" due to the polling, even when the user is completely idle.

## Root cause

`APIHandler._track_activity` defaults to `True`. Every response from a handler with this flag calls `update_api_activity()`, resetting the idle timer. Since the launchpad frontend polls every 10 seconds, the timer never reaches the configured timeout.

## Fix

Set `_track_activity = False` on `DatabaseHandler`. This is the standard jupyter_server pattern for non-user-initiated API traffic (e.g., `APIVersionHandler` in jupyter_server itself uses the same override). The polling continues to work normally with no UX change — the requests simply no longer count as user activity.

## Discovery context

This was identified via binary search across all 23 installed JupyterLab extensions in nebari-data-science-pack. jupyterlab-launchpad was the sole extension preventing idle server shutdown.

See: https://github.com/nebari-dev/nebari-data-science-pack/issues/36